### PR TITLE
Added 'met_dir' in the general options

### DIFF
--- a/acolite/acolite/acolite_cli.py
+++ b/acolite/acolite/acolite_cli.py
@@ -54,6 +54,9 @@ def acolite_cli(*args):
     if 'output' not in acolite_settings:
         print('No output specified in settings file.')
         return(1)
+    import acolite as pp
+    if 'met_dir' in acolite_settings:
+        pp.config['met_dir'] = acolite_settings['met_dir']
 
     logfile = '{}/{}'.format(acolite_settings['output'],'acolite_run_{}_log.txt'.format(acolite_settings['runid']))
     log = LogTee(logfile)

--- a/acolite/acolite/acolite_cli.py
+++ b/acolite/acolite/acolite_cli.py
@@ -54,9 +54,6 @@ def acolite_cli(*args):
     if 'output' not in acolite_settings:
         print('No output specified in settings file.')
         return(1)
-    import acolite as pp
-    if 'met_dir' in acolite_settings:
-        pp.config['met_dir'] = acolite_settings['met_dir']
 
     logfile = '{}/{}'.format(acolite_settings['output'],'acolite_run_{}_log.txt'.format(acolite_settings['runid']))
     log = LogTee(logfile)

--- a/acolite/acolite/acolite_run.py
+++ b/acolite/acolite/acolite_run.py
@@ -19,13 +19,13 @@
 def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, settings=None, quiet=False, ancillary=False, gui=False):
     import os, sys
     import datetime, time
-
-    from acolite import acolite
+    
+    from acolite import acolite, config
     from acolite.output import nc_to_geotiff
-
+ 
     print('Launching ACOLITE Python!')
     setu = acolite.acolite_settings(settings)
-
+    
     ## set variables from settings file if not directly provided by user
     if (inputfile is not None): setu['inputfile'] = inputfile
     if (output is not None): setu['output'] = output
@@ -54,6 +54,9 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
     ## set output if not defined
     if ('output' not in setu): 
         setu['output'] = os.path.dirname(inputfile[0])
+    
+    ## check if there is a met_dir
+    if ('met_dir' in setu): config['met_dir'] = setu['met_dir']
 
     ## force limit to None if not provided
     if ('limit' not in setu): 


### PR DESCRIPTION
Added 3 lines to recognise 'met_dir' as an option in the settings_file. 
This is useful in situations where acolite is installed in an environment without root permission (eg conda package in a VM) where the software cannot write in the path decided inside the config.txt and the config.txt cannot be changed.
The new lines added also allow to choose the met_dirin each computation without changing permanently the config.txt.