### PR TITLE
Added enconding "utf-8" while opening "computed_refri_T27_S0.dat", improved usability while writing l2w_parameters

### DIFF
--- a/acolite/acolite/acolite_cli.py
+++ b/acolite/acolite/acolite_cli.py
@@ -54,6 +54,9 @@ def acolite_cli(*args):
     if 'output' not in acolite_settings:
         print('No output specified in settings file.')
         return(1)
+    import acolite as pp
+    if 'met_dir' in acolite_settings:
+        pp.config['met_dir'] = acolite_settings['met_dir']
 
     logfile = '{}/{}'.format(acolite_settings['output'],'acolite_run_{}_log.txt'.format(acolite_settings['runid']))
     log = LogTee(logfile)

--- a/acolite/acolite/acolite_cli.py
+++ b/acolite/acolite/acolite_cli.py
@@ -54,9 +54,6 @@ def acolite_cli(*args):
     if 'output' not in acolite_settings:
         print('No output specified in settings file.')
         return(1)
-    import acolite as pp
-    if 'met_dir' in acolite_settings:
-        pp.config['met_dir'] = acolite_settings['met_dir']
 
     logfile = '{}/{}'.format(acolite_settings['output'],'acolite_run_{}_log.txt'.format(acolite_settings['runid']))
     log = LogTee(logfile)

--- a/acolite/acolite/acolite_run.py
+++ b/acolite/acolite/acolite_run.py
@@ -43,6 +43,9 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
     if setu['l2w_parameters'] is not None:
         if ('bt10' in setu['l2w_parameters']) or ('bt11' in setu['l2w_parameters']):
             setu['l8_output_bt'] = True
+
+    if type(setu['l2w_parameters']) is not list: 
+        setu['l2w_parameters'] = [setu['l2w_parameters']]
     
     setu['l2w_parameters'] = [par.strip() for par in setu['l2w_parameters']]   
 

--- a/acolite/acolite/acolite_run.py
+++ b/acolite/acolite/acolite_run.py
@@ -47,6 +47,10 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
         print('Please use the CLI for ancillary download.')
         setu['ancillary_data'] = False
 
+    ## check if met_dir is provided
+    if ('met_dir' in setu):
+        config['met_dir'] = setu['met_dir']
+
     ## check if we have an inputfile
     if (setu['inputfile'] is None):
         print('No inputfile given. Exiting.')
@@ -56,9 +60,6 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
     if ('output' not in setu): 
         setu['output'] = os.path.dirname(inputfile[0])
     
-    ## check if there is a met_dir
-    if ('met_dir' in setu): config['met_dir'] = setu['met_dir']
-
     ## force limit to None if not provided
     if ('limit' not in setu): 
         setu['limit'] = None

--- a/acolite/acolite/acolite_run.py
+++ b/acolite/acolite/acolite_run.py
@@ -55,7 +55,7 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
     
     ## removing any space between commas and the parameter name.
     if setu['l2w_parameters'] is not None: 
-        setu['l2w_parameters'] = [par.strip() for par in setu['l2w_parameters' if par]]
+        setu['l2w_parameters'] = [par.strip() for par in setu['l2w_parameters'] if par]
 
     if (gui) & (setu['ancillary_data']): 
         print('Disabling ancillary data in GUI due to download bug.')

--- a/acolite/acolite/acolite_run.py
+++ b/acolite/acolite/acolite_run.py
@@ -19,13 +19,13 @@
 def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, settings=None, quiet=False, ancillary=False, gui=False):
     import os, sys
     import datetime, time
-
-    from acolite import acolite
+    
+    from acolite import acolite, config
     from acolite.output import nc_to_geotiff
-
+ 
     print('Launching ACOLITE Python!')
     setu = acolite.acolite_settings(settings)
-
+    
     ## set variables from settings file if not directly provided by user
     if (inputfile is not None): setu['inputfile'] = inputfile
     if (output is not None): setu['output'] = output
@@ -54,6 +54,9 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
     ## set output if not defined
     if ('output' not in setu): 
         setu['output'] = os.path.dirname(inputfile[0])
+    
+    ## check if there is a met_dir
+    if ('met_dir' in setu): config['met_dir'] = setu['met_dir']
 
     ## force limit to None if not provided
     if ('limit' not in setu): 

--- a/acolite/acolite/acolite_run.py
+++ b/acolite/acolite/acolite_run.py
@@ -48,12 +48,14 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
             setu['l8_output_bt'] = True
         if ('lt10' in setu['l2w_parameters']) or ('lt11' in setu['l2w_parameters']):
             setu['l8_output_lt_tirs'] = True
-
+    
+    ## making sure that the type is a list for the next step
     if setu['l2w_parameters'] is not None and type(setu['l2w_parameters']) is not list: 
         setu['l2w_parameters'] = [setu['l2w_parameters']]
-
+    
+    ## removing any space between commas and the parameter name.
     if setu['l2w_parameters'] is not None: 
-        setu['l2w_parameters'] = [par.strip() for par in setu['l2w_parameters']]
+        setu['l2w_parameters'] = [par.strip() for par in setu['l2w_parameters' if par]]
 
     if (gui) & (setu['ancillary_data']): 
         print('Disabling ancillary data in GUI due to download bug.')

--- a/acolite/acolite/acolite_run.py
+++ b/acolite/acolite/acolite_run.py
@@ -44,10 +44,11 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
         if ('bt10' in setu['l2w_parameters']) or ('bt11' in setu['l2w_parameters']):
             setu['l8_output_bt'] = True
 
-    if type(setu['l2w_parameters']) is not list: 
+    if setu['l2w_parameters'] is not None and type(setu['l2w_parameters']) is not list: 
         setu['l2w_parameters'] = [setu['l2w_parameters']]
-    
-    setu['l2w_parameters'] = [par.strip() for par in setu['l2w_parameters']]   
+
+    if setu['l2w_parameters'] is not None: 
+        setu['l2w_parameters'] = [par.strip() for par in setu['l2w_parameters']]
 
     if (gui) & (setu['ancillary_data']): 
         print('Disabling ancillary data in GUI due to download bug.')

--- a/acolite/acolite/acolite_run.py
+++ b/acolite/acolite/acolite_run.py
@@ -43,6 +43,8 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
     if setu['l2w_parameters'] is not None:
         if ('bt10' in setu['l2w_parameters']) or ('bt11' in setu['l2w_parameters']):
             setu['l8_output_bt'] = True
+    
+    setu['l2w_parameters'] = [par.strip() for par in setu['l2w_parameters']]   
 
     if (gui) & (setu['ancillary_data']): 
         print('Disabling ancillary data in GUI due to download bug.')

--- a/acolite/acolite/acolite_run.py
+++ b/acolite/acolite/acolite_run.py
@@ -25,10 +25,10 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
 
     from acolite import acolite, config
     from acolite.output import nc_to_geotiff
- 
+
     print('Launching ACOLITE Python!')
     setu = acolite.acolite_settings(settings)
-    
+
     ## set variables from settings file if not directly provided by user
     if (inputfile is not None): setu['inputfile'] = inputfile
     if (output is not None): setu['output'] = output
@@ -61,7 +61,7 @@ def acolite_run(inputfile=None, output=None, limit=None, merge_tiles=None, setti
     ## set output if not defined
     if ('output' not in setu): 
         setu['output'] = os.path.dirname(inputfile[0])
-    
+
     ## force limit to None if not provided
     if ('limit' not in setu): 
         setu['limit'] = None

--- a/acolite/shared/read_refri.py
+++ b/acolite/shared/read_refri.py
@@ -7,7 +7,7 @@ def read_refri():
     file = '{}/{}'.format(ac.config['pp_data_dir'], 'Shared/WOPP/computed_refri_T27_S0.dat')
 
     data = {'wave':[], 'n':[]}
-    with open(file, 'r') as f:
+    with open(file, 'r', encoding="utf-8") as f:
         for line in f.readlines():
             if line[0] in ['%', '#', ';']: continue
             line = line.strip()


### PR DESCRIPTION
The open() function in the script _acolite/shared/read_refri.py_ has no encoding specification.

While this is not generally needed, in certain environment (e.g. acolite package used by a docker image) this would be necessary to exploit the _glint correction_ option.

This is due to the fact that there are utf-8 charachters in the _computed_refri_T27_S0.dat_ file (
`% R. Röttgers, HZG`).

Usually the encoding utf-8 is specified in other acolite files.