### PR TITLE
Fix type of the third argument to linspace

### DIFF
--- a/acolite/sentinel/scene_meta.py
+++ b/acolite/sentinel/scene_meta.py
@@ -7,6 +7,7 @@
 ##                2017-11-22 (QV) added defaults for the model selection
 ##                2018-07-18 (QV) changed acolite import name
 ##                2018-10-01 (QV) removed obsolete bits
+##                2020-06-02 (SV) ensure that linspace gets an integer as its third argument
 
 def scene_meta(metafile):
     import dateutil.parser
@@ -72,7 +73,7 @@ def scene_meta(metafile):
         if len(tag) > 0:
             step = float(tag[0].getElementsByTagName('STEP')[0].firstChild.nodeValue)
             rsr = [float(rs) for rs in tag[0].getElementsByTagName('VALUES')[0].firstChild.nodeValue.split(' ')]
-            wave = linspace(banddata['Wavelength'][band]['MIN'],banddata['Wavelength'][band]['MAX'], ((banddata['Wavelength'][band]['MAX']-banddata['Wavelength'][band]['MIN'])/step)+1)                                                                                                                                                            
+            wave = linspace(banddata['Wavelength'][band]['MIN'],banddata['Wavelength'][band]['MAX'], int(ceil(((banddata['Wavelength'][band]['MAX']-banddata['Wavelength'][band]['MIN'])/step)+1)))                                                                                                                                                            
         banddata['RSR'][band] = {'response':rsr, 'wave':wave}
     #print(banddata['Wavelength'])
 

--- a/acolite/sentinel/scene_meta.py
+++ b/acolite/sentinel/scene_meta.py
@@ -14,7 +14,7 @@ def scene_meta(metafile):
     from xml.dom import minidom
         
     from acolite.shared import distance_se
-    from numpy import linspace
+    from numpy import linspace, ceil
 
     try: 
         xmldoc = minidom.parse(metafile)

--- a/acolite/shared/rsr_convolute_dict.py
+++ b/acolite/shared/rsr_convolute_dict.py
@@ -4,12 +4,13 @@
 ## 2016-11
 ## modifications: 2017-10-17 (QV) moved wave range and step to keywords, renamed from interprsr
 ##                2020-03-02 (QV) added ceil to number of elements in linspace
+##                2020-06-02 (SV) pass ceil to int to ensure that linspace gets an integer argument
 
 def rsr_convolute_dict(wave_data, data, rsr, wave_range=[0.2,2.4], wave_step=0.001):
     from numpy import linspace, interp, nan, zeros, ceil
     
     ## set up wavelength space
-    wave_hyper = linspace(wave_range[0],wave_range[1],ceil(((wave_range[1]-wave_range[0])/wave_step)+2))
+    wave_hyper = linspace(wave_range[0],wave_range[1],int(ceil(((wave_range[1]-wave_range[0])/wave_step)+2)))
 
     ## interpolate RSR to same dimensions
     rsr_hyper = dict()

--- a/acolite/shared/sensor_wave.py
+++ b/acolite/shared/sensor_wave.py
@@ -5,6 +5,7 @@
 ## modifications: 
 ##                2018-07-18 (QV) changed acolite import name
 ##                2020-03-02 (QV) added ceil to number of elements in linspace
+##                2020-06-02 (SV) pass ceil to int to ensure that linspace gets an integer argument
 
 def sensor_wave(satsen, wave_range = (0.39,2.4), wave_step = 0.001):
     from numpy import linspace, ceil
@@ -14,7 +15,7 @@ def sensor_wave(satsen, wave_range = (0.39,2.4), wave_step = 0.001):
     rsr_file = pp_path+'/RSR/'+satsen+'.txt'
     rsr, rsr_bands = rsr_read(file=rsr_file)
     
-    wave_hyper = linspace(wave_range[0],wave_range[1],ceil(((wave_range[1]-wave_range[0])/wave_step)+2))
+    wave_hyper = linspace(wave_range[0],wave_range[1],int(ceil(((wave_range[1]-wave_range[0])/wave_step)+2)))
 
     rsr_wave = rsr_convolute_dict(wave_hyper, wave_hyper, rsr)
     waves = {rband:'{:.0f}'.format(round(rsr_wave[rband]*1000.)) for rband in rsr_wave}


### PR DESCRIPTION
Three files need to be modified for the newest `numpy ` versions since `linspace` no longer accepts floats as its third argument. Expands on commit 650331e634940fe7c9a0d8c6ff0d72855d5ae593 and resolves issue #5 .