### PR TITLE
Fixed gdal import in nc_to_geotiff

### DIFF
--- a/acolite/output/nc_to_geotiff.py
+++ b/acolite/output/nc_to_geotiff.py
@@ -14,7 +14,7 @@ def nc_to_geotiff(f, skip_geo=True):
     tags += ['output_dir', 'output_base', 'sensor']
 
     if all([t in gatts for t in tags]):
-        import osgeo.osr, gdal
+        from osgeo import osr, gdal
 
         xrange = gatts['xrange']
         yrange = gatts['yrange']
@@ -22,7 +22,7 @@ def nc_to_geotiff(f, skip_geo=True):
         pixel_size = gatts['pixel_size']
 
         ## make WKT
-        srs = osgeo.osr.SpatialReference()
+        srs = osr.SpatialReference()
         srs.ImportFromProj4(gatts['proj4_string'])
         wkt = srs.ExportToWkt()
 


### PR DESCRIPTION
I have encountered an error lately with geotiff output files.

```
Traceback (most recent call last):
  File "/home/thibaut/thibaut/acolite/acolite/launch_acolite.py", line 30, in <module>
    launch_acolite()
  File "/home/thibaut/thibaut/acolite/acolite/launch_acolite.py", line 25, in launch_acolite
    ac.acolite.acolite_cli(sys.argv)
  File "/home/thibaut/thibaut/acolite/acolite/acolite/acolite/acolite_cli.py", line 71, in acolite_cli
    acolite_run(settings=acolite_settings)
  File "/home/thibaut/thibaut/acolite/acolite/acolite/acolite/acolite_run.py", line 337, in acolite_run
    for f in ret: nc_to_geotiff(f, skip_geo=(not setu['export_geotiff_coordinates']))
  File "/home/thibaut/thibaut/acolite/acolite/acolite/output/nc_to_geotiff.py", line 17, in nc_to_geotiff
    import osgeo.osr, gdal
ModuleNotFoundError: No module named 'gdal'
```

It seems to be caused by the gdal import in `nc_to_geotiff`, and this fixes the issue.

Please let me know if that makes sense !