### PR TITLE
Fix bug in EXP correction

### DIFF
--- a/acolite/acolite/acolite_ac.py
+++ b/acolite/acolite/acolite_ac.py
@@ -1480,7 +1480,7 @@ def acolite_ac(bundle, odir,
                     mask_data = pp.sentinel.get_rtoa(bundle, metadata, bdata, safe_files[granule], \
                                                       ordered_bands[swir1_idx], target_res=s2_target_res, sub=grids)
             ## apply gains
-            if (gains) & (band_name in gains_dict):
+            if (gains) & (ordered_bands[short_idx] in gains_dict) & (ordered_bands[long_idx] in gains_dict):
                 short_data *= gains_dict[ordered_bands[short_idx]]
                 long_data *= gains_dict[ordered_bands[long_idx]]
                 print('Applied gain {} for band {}'.format(gains_dict[ordered_bands[short_idx]],band_names[short_idx]))


### PR DESCRIPTION
Without this modification, the EXP correction fails with "UnboundLocalError: local variable 'band_name' referenced before assignment" as the variable `band_name` is not defined up to this point. What actually should be tested is if `ordered_bands[short_idx]` and `ordered_bands[long_idx]` are in the dictionary or not.